### PR TITLE
Conflict with v2 series of `laminas-i18n`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,12 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "^3.1",
-        "phpunit/phpunit": "^11.5.46",
-        "psalm/plugin-phpunit": "^0.19.5",
-        "vimeo/psalm": "^6.14.2"
+        "phpunit/phpunit": "^11.5.55",
+        "psalm/plugin-phpunit": "^0.19.7",
+        "vimeo/psalm": "^6.16.1"
+    },
+    "conflict": {
+        "laminas/laminas-i18n": "<3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c04059cd9b29e21401f7912135e46609",
+    "content-hash": "667320e4b2daa796d38f1511ebb26f67",
     "packages": [
         {
             "name": "brick/varexporter",

--- a/tools/infection/composer.json
+++ b/tools/infection/composer.json
@@ -15,9 +15,9 @@
         "psr/container": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "psalm/plugin-phpunit": "^0.19.5",
+        "psalm/plugin-phpunit": "^0.19.7",
         "roave/infection-static-analysis-plugin": "^1.40",
-        "vimeo/psalm": "^6.14.2"
+        "vimeo/psalm": "^6.16.1"
     },
     "autoload": {
         "psr-4": {

--- a/tools/infection/composer.lock
+++ b/tools/infection/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7428697ffd7f0e5a2d92e130b1f8078c",
+    "content-hash": "e93684f41269ba56544b6aa82b504839",
     "packages": [
         {
             "name": "brick/varexporter",

--- a/tools/rector/composer.json
+++ b/tools/rector/composer.json
@@ -5,6 +5,6 @@
         }
     },
     "require-dev": {
-        "rector/rector": "^2.2.14"
+        "rector/rector": "^2.4.3"
     }
 }

--- a/tools/rector/composer.lock
+++ b/tools/rector/composer.lock
@@ -4,16 +4,16 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f6f4af58ec1bda54f2f805d267eccfa2",
+    "content-hash": "60bdee938e0da8fb3f2326e6d66a14a5",
     "packages": [],
     "packages-dev": [
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.54",
+            "version": "2.1.55",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
-                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9eaac3826ed5e9b8427350a43cac825eeca3f566",
+                "reference": "9eaac3826ed5e9b8427350a43cac825eeca3f566",
                 "shasum": ""
             },
             "require": {
@@ -58,7 +58,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-29T13:31:09+00:00"
+            "time": "2026-05-18T11:57:34+00:00"
         },
         {
             "name": "rector/rector",

--- a/tools/unused/composer.json
+++ b/tools/unused/composer.json
@@ -5,6 +5,6 @@
         }
     },
     "require-dev": {
-        "icanhazstring/composer-unused": "^0.9.5"
+        "icanhazstring/composer-unused": "^0.9.6"
     }
 }

--- a/tools/unused/composer.lock
+++ b/tools/unused/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12accc88d42cdd9da43f8452a1c5be31",
+    "content-hash": "d427f02bb119519c64263443f6f6e6ed",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
Version 1.0 of this lib will only be compatible with SMv4 supporting libs, i.e. `laminas/laminas-filter@3.x`. It also has namespace conflicts with any i18n release in the 2.x series.

Also bumps all dev deps, refresh locks.

Once this is merged, v1.0 should be OK to release as it does not depend on i18n directly.

